### PR TITLE
[IconPack Add] lenno.MacroDeckSleepFirefly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -229,3 +229,6 @@
 [submodule "Plugins/LeoM.Cs2Gsi"]
 	path = Plugins/LeoM.Cs2Gsi
 	url = https://github.com/leo-divini/CS2_Macro_Deck_Plugin
+[submodule "IconPacks/lenno.MacroDeckSleepFirefly"]
+	path = IconPacks/lenno.MacroDeckSleepFirefly
+	url = https://github.com/LennonAmos/MacroDeckSleepFirefly.git


### PR DESCRIPTION
### Checklist:
- [x] I used the latest version to develop and test the Extension
- [x] I used the workflow to add the Extension
- [x] I have not added any files manually to the Macro-Deck-Extensions repository
- [x] The added Extension is tested and works
- [x] The added Extension meets the rules
- [x] The repository of my Extension meets the required file structure

### Changes
Adds a locally generated animated MacroDeck Sleep Mode icon pack.