### PR TITLE
Add Pear Desktop Plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -277,3 +277,6 @@
 [submodule "Plugins/tabsik12.TimeDateSplit"]
 	path = Plugins/tabsik12.TimeDateSplit
 	url = https://github.com/tabsik30/TimeDateSplit
+[submodule "Plugins/rxlee.PearMacroDeck"]
+	path = Plugins/rxlee.PearMacroDeck
+	url = https://github.com/rxlee123/macrodeck-pear-desktop-plugin


### PR DESCRIPTION
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] I used the latest version to develop and test the Extension
- [ x] I used the workflow to add the Extension ([described here](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#add-your-extension-to-the-extension-store))
- [x ] I have not added any files manually to the Macro-Deck-Extensions repository
- [x ] The added Extension is tested and works
- [x ] The added Extension meets [the rules](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#rules)
- [x ] The repository of my Extension meets the [required file structure](https://github.com/Macro-Deck-App/Macro-Deck-Extensions#repository-root-file-structure)

**Note to reviewers:**
The automated "Add/Update Extension" GitHub Action workflow is currently broken on `main`. It crashes during the `Clean branch` step with exit code 1 because the `TwigYT.MacroDeck.MaterialDesignIconsPack` submodule no longer exists (the repository was deleted by the author). 
Because the workflow crashes trying to update that dead submodule, I manually added my plugin's submodule (`rxlee.PearMacroDeck`) and created this PR. 
