### PR TITLE
Add FuSan21.TeamsPlugin — Microsoft Teams meeting control

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -280,3 +280,6 @@
 [submodule "Plugins/ziopuzzle.WebRequest"]
 	path = Plugins/ziopuzzle.WebRequest
 	url = https://github.com/ziopuzzle/MacroDeck-WebRequest
+[submodule "Plugins/FuSan21.TeamsPlugin"]
+	path = Plugins/FuSan21.TeamsPlugin
+	url = https://github.com/FuSan21/Macro-Deck-Teams-Plugin


### PR DESCRIPTION
Adds **Teams Plugin** — control Microsoft Teams meetings from Macro Deck with live state.

- **Package ID:** `FuSan21.TeamsPlugin`
- **Repository:** https://github.com/FuSan21/Macro-Deck-Teams-Plugin
- **Version:** 1.0.0 (tag `v1.0.0`)
- **Target plugin API:** 41 · **Target Macro Deck:** 2.15.0

### What it does

9 actions — mute, camera, raise hand, screen share, recording, chat panel, people panel, reactions (Like/Love/Applause/Laugh/Surprised) and leave — plus 6 state variables that update live, including changes made inside Teams itself.

It also writes a platform-neutral `meeting_*` set while in a call, so one button layout could serve several meeting plugins.

### How it works

Microsoft retired the Teams local WebSocket API on 30 June 2026 ([MC1266901](https://mc.merill.net/message/MC1266901)) with no replacement, so this uses **Windows UI Automation** instead. Controls are addressed by `AutomationId`, which is language-independent, and activated via the Invoke pattern — so Teams never takes focus and it works while minimised or in compact view.

State is read from the control labels, which *are* translated; English is built in and the configuration has a one-step calibration for other languages.

### Notes for review

- Dependencies are NuGet `PackageReference` only (FlaUI.UIA3, Newtonsoft.Json, SuchByte.MacroDeck) — no committed DLLs.
- The plugin needs a one-off, **opt-in** accessibility activation: Teams' browser engine only builds an accessibility tree when it believes assistive software is running, so the plugin briefly raises the Windows screen-reader flag and restores it immediately. It is off by default and explained in the README.
- There is an enable/disable switch, so the integration can be turned off without uninstalling.